### PR TITLE
fixed server not registering player id

### DIFF
--- a/Assets/ServerConnection.cs
+++ b/Assets/ServerConnection.cs
@@ -50,6 +50,7 @@ public class ServerConnection : NetworkBehaviour
             return;
         }
         uint id = (uint)Variable.DictPlayersId.Count;
+        PlayerId = id;
         Variable.DictPlayersId[playerName] = id;
         Variable.DictPlayerScorePerHole[id] = new Dictionary<uint, uint>() {[Variable.CurrentHole] = 0};
         SetPlayerIdClientRpc(id);


### PR DESCRIPTION
fixed server not registering player id in player's class instance on connection, resulting in errors when logging ball hits with player's id